### PR TITLE
Use star rating formula that better correlates with pp.

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -34,7 +34,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double aimRating = Math.Sqrt(skills[0].DifficultyValue()) * difficulty_multiplier;
             double speedRating = Math.Sqrt(skills[1].DifficultyValue()) * difficulty_multiplier;
-            double starRating = aimRating + speedRating + Math.Abs(aimRating - speedRating) / 2;
+            
+            double baseAimPerformance = Math.Pow(5.0 * Math.Max(1.0, aimRating) - 4.0, 3.0) / 100000;
+            double baseSpeedPerformance = Math.Pow(5.0 * Math.Max(1.0, speedRating) - 4.0, 3.0) / 100000;
+            double basePerformance = Math.Pow(Math.Pow(baseAimPerformance, 1.1) + Math.Pow(baseSpeedPerformance, 1.1), 1.0 / 1.1);
+            double starRating = basePerformance > 0.00001 ? 0.027 * (Math.Cbrt(100000 / Math.Pow(2.0, 1.0 / 1.1) * basePerformance) + 4.0) : 0;
 
             HitWindows hitWindows = new OsuHitWindows();
             hitWindows.SetDifficulty(beatmap.BeatmapInfo.BaseDifficulty.OverallDifficulty);


### PR DESCRIPTION
Please see this document for the explanation and justification behind this change: https://docs.google.com/document/d/10DZGYYSsT_yjz2Mtp6yIJld0Rqx4E-vVHupCqiM4TNI/edit?usp=sharing

The purpose of this change is to increase the correlation between star rating and pp. The change alters the combined star rating formula from `aim + speed + abs(aim - speed) / 2` to the formula shown in the document.

(Also, apologies if I made a mistake in the code or presentation, this is my first pull request.)