### PR TITLE
Increase accuracy of relevant speed circle count

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         public double SliderFactor { get; set; }
 
         [JsonProperty("speed_relevant_note_count")]
-        public double SpeedRelevantNoteCount { get; set; }
+        public double SpeedRelevantCircleCount { get; set; }
 
         /// <summary>
         /// The perceived approach rate inclusive of rate-adjusting mods (DT/HT/etc).

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double sliderFactor = aimRating > 0 ? aimRatingNoSliders / aimRating : 1;
 
-            double speedRelevantNoteCount = ((OsuStrainSkill)skills[2]).CountRelevantNotes();
+            double speedRelevantCircleCount = ((OsuStrainSkill)skills[2]).CountRelevantCircles();
 
             if (mods.Any(h => h is OsuModRelax))
                 speedRating = 0.0;
@@ -80,7 +80,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 SpeedDifficulty = speedRating,
                 FlashlightDifficulty = flashlightRating,
                 SliderFactor = sliderFactor,
-                SpeedRelevantNoteCount = speedRelevantNoteCount,
+                SpeedRelevantCircleCount = speedRelevantCircleCount,
                 ApproachRate = preempt > 1200 ? (1800 - preempt) / 120 : (1200 - preempt) / 150 + 5,
                 OverallDifficulty = (80 - hitWindowGreat) / 6,
                 DrainRate = drainRate,

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -249,21 +249,18 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         private double? calculateSpeedDeviation(OsuDifficultyAttributes attributes)
         {
-            if (attributes.HitCircleCount == 0)
+            if (attributes.SpeedRelevantCircleCount == 0)
                 return null;
 
-            // Max speed circle count as speed relevant note count can be higher than circle count
-            double speedCircleCount = Math.Min(attributes.SpeedRelevantNoteCount, attributes.HitCircleCount);
+            double greatCountOnSpeedCircles = Math.Max(0, countGreat - (attributes.HitCircleCount - attributes.SpeedRelevantCircleCount) - attributes.SliderCount - attributes.SpinnerCount);
 
-            double greatCountOnSpeedCircles = Math.Max(0, countGreat - (attributes.HitCircleCount - speedCircleCount) - attributes.SliderCount - attributes.SpinnerCount);
-
-            if (greatCountOnSpeedCircles == 0 || speedCircleCount - countMiss <= 0)
+            if (greatCountOnSpeedCircles == 0 || attributes.SpeedRelevantCircleCount - countMiss <= 0)
                 return null;
 
             double greatHitWindow = 80 - 6 * attributes.OverallDifficulty;
 
             // Add 1 circle so that SS scores don't break.
-            double greatProbability = greatCountOnSpeedCircles / (speedCircleCount - countMiss + 1.0);
+            double greatProbability = greatCountOnSpeedCircles / (attributes.SpeedRelevantCircleCount - countMiss + 1.0);
             double deviation = greatHitWindow / (Math.Sqrt(2) * SpecialFunctions.ErfInv(greatProbability));
 
             return deviation;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
         /// </summary>
         protected virtual double DifficultyMultiplier => 1.06;
 
-        protected List<double> objectStrains = new List<double>();
+        protected List<double> CircleStrains = new List<double>();
 
         protected OsuStrainSkill(Mod[] mods)
             : base(mods)
@@ -60,12 +60,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             return difficulty * DifficultyMultiplier;
         }
 
-        public double CountRelevantNotes()
+        public double CountRelevantCircles()
         {
-            List<double> strains = GetCurrentStrainPeaks().ToList();
-            double topStrain = objectStrains.Max();
+            double topStrain = CircleStrains.Max();
 
-            return objectStrains.Sum(s => s / topStrain);
+            return CircleStrains.Sum(s => s / topStrain);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/OsuStrainSkill.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using osu.Game.Rulesets.Difficulty.Skills;
-using osu.Game.Rulesets.Mods;
 using System.Linq;
 using osu.Framework.Utils;
+using osu.Game.Rulesets.Difficulty.Skills;
+using osu.Game.Rulesets.Mods;
 
 namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 {
@@ -62,6 +62,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         public double CountRelevantCircles()
         {
+            if (CircleStrains.Count == 0)
+                return 0;
+
             double topStrain = CircleStrains.Max();
 
             return CircleStrains.Sum(s => s / topStrain);

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -2,11 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Objects;
-using osu.Framework.Utils;
 
 namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 {
@@ -171,7 +171,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
             double totalStrain = currentStrain * currentRhythm;
 
-            if(current.BaseObject is HitCircle)
+            if (current.BaseObject is HitCircle)
                 CircleStrains.Add(totalStrain);
 
             return totalStrain;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Speed.cs
@@ -171,7 +171,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
             double totalStrain = currentStrain * currentRhythm;
 
-            objectStrains.Add(totalStrain);
+            if(current.BaseObject is HitCircle)
+                CircleStrains.Add(totalStrain);
 
             return totalStrain;
         }


### PR DESCRIPTION
Realized I could just filter out sliders when adding per note strains to the relevant speed notes method, including a bit of cleaning up. Renamed the objectStrains list to CircleStrains to keep compatibility with Apollo's combo scaling rework.